### PR TITLE
Add per domain loss over trainning

### DIFF
--- a/examples/config_tiny_llama.yaml
+++ b/examples/config_tiny_llama.yaml
@@ -11,8 +11,8 @@ data_stages:
       dataset_processing_num_proc_per_process: 1
       hf_dataset_config_name: null
       hf_dataset_or_datasets:
-        stas/openwebtext-10k: 1.0
-        roneneldan/TinyStories: 0.05
+        stas/openwebtext-10k: 0.1
+        roneneldan/TinyStories: 0.01
       hf_dataset_splits: train
       text_column_name: text
     num_loading_workers: 1

--- a/examples/config_tiny_llama.yaml
+++ b/examples/config_tiny_llama.yaml
@@ -10,7 +10,9 @@ data_stages:
       dataset_overwrite_cache: false
       dataset_processing_num_proc_per_process: 1
       hf_dataset_config_name: null
-      hf_dataset_or_datasets: stas/openwebtext-10k
+      hf_dataset_or_datasets:
+        stas/openwebtext-10k: 1.0
+        roneneldan/TinyStories: 0.05
       hf_dataset_splits: train
       text_column_name: text
     num_loading_workers: 1

--- a/examples/config_tiny_llama.yaml
+++ b/examples/config_tiny_llama.yaml
@@ -87,7 +87,7 @@ optimizer:
   weight_decay: 0.01
   zero_stage: 0
 parallelism:
-  dp: 2
+  dp: 1
   expert_parallel_size: 1
   pp: 1
   pp_engine: 1f1b

--- a/run_train.py
+++ b/run_train.py
@@ -96,6 +96,7 @@ def get_dataloader_from_data_stage(
                 splits=data.dataset.hf_dataset_splits,
             )
             raw_dataset = raw_dataset["train"]
+            trainer.set_domain_name_id_mappings(domain_name2id)
 
             tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
             tokenizer.pad_token = tokenizer.eos_token
@@ -117,8 +118,6 @@ def get_dataloader_from_data_stage(
                 return_domain_ids=True,
                 domain_name_to_id=domain_name2id,
             )
-
-            # TODO (sguo): update the following part to include 'domain_id' column of train_dataset
 
             # We load the processed dataset on the ranks requiring it
             dataloader = get_train_dataloader(

--- a/run_train.py
+++ b/run_train.py
@@ -90,11 +90,12 @@ def get_dataloader_from_data_stage(
             # TODO: generalise to include  for validation/test splits
 
             # We load the raw dataset
-            raw_dataset = get_datasets(
+            raw_dataset, domain_name2id = get_datasets(
                 hf_dataset_or_datasets=data.dataset.hf_dataset_or_datasets,
                 hf_dataset_config_name=data.dataset.hf_dataset_config_name,
                 splits=data.dataset.hf_dataset_splits,
-            )["train"]
+            )
+            raw_dataset = raw_dataset["train"]
 
             tokenizer = AutoTokenizer.from_pretrained(tokenizer_path)
             tokenizer.pad_token = tokenizer.eos_token
@@ -113,7 +114,11 @@ def get_dataloader_from_data_stage(
                 dataset_processing_num_proc_per_process=data.dataset.dataset_processing_num_proc_per_process,
                 dataset_overwrite_cache=data.dataset.dataset_overwrite_cache,
                 sequence_length=trainer.sequence_length,
+                return_domain_ids=True,
+                domain_name_to_id=domain_name2id,
             )
+
+            # TODO (sguo): update the following part to include 'domain_id' column of train_dataset
 
             # We load the processed dataset on the ranks requiring it
             dataloader = get_train_dataloader(
@@ -128,6 +133,7 @@ def get_dataloader_from_data_stage(
                 seed_worker=data.seed,
                 dataloader_drop_last=True,
             )
+
 
             # Check if we have enough samples for train_steps
             total_tokens_dataset = len(dataloader.dataset) * trainer.sequence_length

--- a/src/nanotron/dataloader.py
+++ b/src/nanotron/dataloader.py
@@ -21,6 +21,7 @@ from nanotron.sanity_checks import (
 try:
     import datasets
     from datasets import (
+        ClassLabel,
         Dataset,
         DatasetDict,
         Features,
@@ -109,7 +110,7 @@ def get_datasets(
         #     - 'dataset1': 0.5
         #     - 'dataset2': 0.3
         #     - 'dataset3': 0.2
-        raw_datasets = _get_dataset_mix(hf_dataset_or_datasets, splits=splits)
+        raw_datasets, domain_name2id = _get_dataset_mix(hf_dataset_or_datasets, splits=splits)
     elif isinstance(hf_dataset_or_datasets, str):
         # e.g. Dataset = "HuggingFaceH4/testing_alpaca_small"
         # Note this returns things other than just train/test, which may not be intended
@@ -120,10 +121,11 @@ def get_datasets(
                 hf_dataset_config_name,
                 split=split,
             )
+        domain_name2id = {hf_dataset_or_datasets: 0}
     else:
         raise ValueError(f"hf_dataset_or_datasets must be a dict or string but is {type(hf_dataset_or_datasets)}")
 
-    return raw_datasets
+    return raw_datasets, domain_name2id
 
 
 def _add_id_column_to_dataset(ds: "DatasetDict", id: int, split: str = 'train') -> "DatasetDict":
@@ -132,7 +134,7 @@ def _add_id_column_to_dataset(ds: "DatasetDict", id: int, split: str = 'train') 
 
 
 # Adapted from h4/src/h4/data/loading.py
-def _get_dataset_mix(dataset_dict: dict, splits: List[str] = None, seed=42) -> "DatasetDict":
+def _get_dataset_mix(dataset_dict: dict, splits: List[str] = None, seed: int = 42) -> "DatasetDict":
     """
     Helper function to load dataset mix from dict configuration.
 
@@ -145,6 +147,8 @@ def _get_dataset_mix(dataset_dict: dict, splits: List[str] = None, seed=42) -> "
     raw_train_datasets = []
     raw_test_datasets = []
     fracs = []
+    domain_name2id = {}
+
     for ds, frac in dataset_dict.items():
         if frac < 0:
             raise ValueError(f"Dataset fraction for dataset {ds} is negative. (= {frac})")
@@ -171,24 +175,26 @@ def _get_dataset_mix(dataset_dict: dict, splits: List[str] = None, seed=42) -> "
     if len(raw_train_datasets) > 0:
         train_subsets = []
         for idx, (dataset, frac) in enumerate(zip(raw_train_datasets, fracs)):
+            domain_name2id[dataset.info.dataset_name] = idx
             train_subset = dataset.select(range(int(frac * len(dataset))))
             train_subset = _add_id_column_to_dataset(train_subset, idx)
             train_subsets.append(train_subset)
-        raw_datasets["train"] = concatenate_datasets(train_subsets).shuffle(seed=seed)
+        raw_datasets["train"] = concatenate_datasets(train_subsets)
+        # we remove the shuffle here to avoid the complexity of adding domain ids
 
     # No subsampling for test datasets to enable fair comparison across models
     if len(raw_test_datasets) > 0:
         test_sets = []
         for idx, raw_test_dataset in enumerate(raw_test_datasets):
             test_sets.append(_add_id_column_to_dataset(raw_test_dataset, idx))
-        raw_datasets["test"] = concatenate_datasets(test_sets).shuffle(seed=seed)
+        raw_datasets["test"] = concatenate_datasets(test_sets)
 
     if len(raw_datasets) == 0:
         raise ValueError(
             f"Dataset {dataset_dict} not recognized with split {split}. Check the dataset has been correctly formatted."
         )
 
-    return raw_datasets
+    return raw_datasets, domain_name2id
 
 
 def dummy_infinite_data_generator(
@@ -295,47 +301,81 @@ def clm_process(
     dataset_overwrite_cache: bool,
     sequence_length: int,
     return_domain_ids: bool = False,
+    domain_id_column_name: str = 'domain_id',
+    domain_name_to_id: Dict[str, int] | None = None,
+    seed: int = 42,
 ):
     """Concatenate all texts from raw_dataset and generate chunks of `sequence_length + 1`, where chunks overlap by a single token."""
     # Adapted from https://github.com/huggingface/transformers/blob/47e1676255e5dd86b9541f734cd4f4bdcbb50f4a/examples/pytorch/language-modeling/run_clm.py#L391-L439
 
-    def group_texts(examples: Dict[str, List[np.ndarray]]) -> Dict[str, List[np.ndarray]]:
-        # Concatenate all texts.
-        concatenated_examples = {k: np.concatenate(v) for k, v in examples.items()}
-        total_length = len(concatenated_examples[next(iter(examples.keys()))])
-        # WARNING: We drop the small remainder, we could add padding if the model supported it instead of this drop, you can
-        # customize this part to your needs.
-        if total_length >= sequence_length + 1:
-            total_length = ((total_length - 1) // sequence_length) * sequence_length + 1
-        # Split by chunks of sequence_length.
-        result = {
-            k: [
-                t[i : i + sequence_length + 1] for i in range(0, total_length - (sequence_length + 1), sequence_length)
-            ]
-            for k, t in concatenated_examples.items()
-        }
+    if return_domain_ids:
+        assert domain_id_column_name in raw_dataset.column_names, """
+            "domain_id" should be one of the columns names when "return_domain_ids" is True
+        """
+        assert domain_name_to_id is not None, """
+            "domain_name_to_id" should be set if "return_domain_ids" is True
+        """
+
+    def group_texts(examples: Dict[str, List[np.ndarray]], domain_ids: List[int]
+    ) -> Dict[str, Union[List[np.ndarray], int]]:
+        for v in examples.values():
+            assert len(v) == len(domain_ids), """
+             The number of elements in "exampls" should be the same to size of "domain_ids"
+            """
+
+        # map domains to examples
+        domain_to_examples = {}
+        for i, domain_id in enumerate(domain_ids):
+            if domain_id not in domain_to_examples:
+                domain_to_examples[domain_id] = {k: [] for k in examples.keys()}
+            for k in examples.keys():
+                domain_to_examples[domain_id][k].append(examples[k][i])
+
+        # concatenate all texts by domains
+        result = {k: [] for k in examples.keys()}
+        result['domain_id'] = []
+
+        for domain_id, domain_data in domain_to_examples.items():
+            concatenated = {k: np.concatenate(v) for k, v in domain_data.items()}
+            total_length = len(concatenated[next(iter(examples.keys()))])
+            # WARNING: We drop the small remainder, we could add padding if the model supported it instead of this 
+            # drop, you can customize this part to your needs.
+            if total_length >= sequence_length + 1:
+                total_length = ((total_length - 1) // sequence_length) * sequence_length + 1
+
+            for k in examples.keys():
+                # split to chunks
+                chunks = [
+                    concatenated[k][i:i+sequence_length+1]
+                    for i in range(0, total_length - (sequence_length + 1), sequence_length)
+                ]
+                result[k].extend(chunks)
+            result['domain_id'].extend([domain_id] * len(chunks))
+
         return result
 
-    def _tokenize_and_group_texts(texts: List[str]) -> Dict[str, List[np.ndarray]]:
+    def _tokenize_and_group_texts_and_ids(texts: List[str], domain_ids: List[int]) -> Dict[str, List[np.ndarray]]:
         tokenized_batch = tokenizer.batch_encode_plus(texts, return_attention_mask=False, return_token_type_ids=False)
         tokenized_batch = {k: [np.array(tokenized_texts) for tokenized_texts in v] for k, v in tokenized_batch.items()}
-        return group_texts(tokenized_batch)
+        return group_texts(tokenized_batch, domain_ids)
 
-    # TODO (sguo): the domain ids should be constructed here, some useful tips are given below
-    # 1. obtain the name of raw_dataset: raw_dataset.info.dataset_name
-    # 2. need a mapping between ids and names
+    _input_columns = text_column_name if not return_domain_ids else [text_column_name, domain_id_column_name]
 
     train_dataset = raw_dataset.map(
-        _tokenize_and_group_texts,
-        input_columns=text_column_name,
+        _tokenize_and_group_texts_and_ids,
+        input_columns=_input_columns,
         remove_columns=raw_dataset.column_names,
-        features=Features({"input_ids": Sequence(feature=Value(dtype="int64"), length=sequence_length + 1)}),
+        features=Features({
+            "input_ids": Sequence(feature=Value(dtype="int64"), length=sequence_length + 1),
+            "domain_id": ClassLabel(num_classes=len(domain_name_to_id), names= list(domain_name_to_id.keys()))
+        }),
         batched=True,
         num_proc=dataset_processing_num_proc_per_process,
         load_from_cache_file=not dataset_overwrite_cache,
         desc=f"Grouping texts in chunks of {sequence_length+1}",
     )
-    return train_dataset
+
+    return train_dataset.shuffle(seed=seed)
 
 
 # Adapted from: https://github.com/huggingface/transformers/blob/47e1676255e5dd86b9541f734cd4f4bdcbb50f4a/src/transformers/data/data_collator.py#L607

--- a/src/nanotron/dataloader.py
+++ b/src/nanotron/dataloader.py
@@ -121,6 +121,7 @@ def get_datasets(
                 hf_dataset_config_name,
                 split=split,
             )
+            raw_datasets[split] = _add_id_column_to_dataset(raw_datasets[split], 0)
         domain_name2id = {hf_dataset_or_datasets: 0}
     else:
         raise ValueError(f"hf_dataset_or_datasets must be a dict or string but is {type(hf_dataset_or_datasets)}")
@@ -310,10 +311,10 @@ def clm_process(
 
     if return_domain_ids:
         assert domain_id_column_name in raw_dataset.column_names, """
-            "domain_id" should be one of the columns names when "return_domain_ids" is True
+            `domain_id` should be one of the columns names when "return_domain_ids" is True
         """
         assert domain_name_to_id is not None, """
-            "domain_name_to_id" should be set if "return_domain_ids" is True
+            `domain_name_to_id` should be set if "return_domain_ids" is True
         """
 
     def group_texts(examples: Dict[str, List[np.ndarray]], domain_ids: List[int]
@@ -407,14 +408,16 @@ class DataCollatorForCLM:
                 "input_mask": TensorPointer(group_rank=self.input_pp_rank),
                 "label_ids": TensorPointer(group_rank=self.output_pp_rank),
                 "label_mask": TensorPointer(group_rank=self.output_pp_rank),
+                "domain_id": TensorPointer(group_rank=self.output_pp_rank),
             }
 
         # Make sure we load only what's necessary, ie we only load a `input_ids` column.
-        assert all(list(example.keys()) == ["input_ids"] for example in examples)
+        assert all(list(example.keys()) == ["input_ids", "domain_id"] for example in examples)
 
         # TODO @nouamanetazi: Is it better to have examples as np.array or torch.Tensor?
         input_ids = np.vstack([examples[i]["input_ids"] for i in range(len(examples))])  # (b, s)
         batch_size, expanded_input_length = input_ids.shape
+        domain_ids = np.array([examples[i]["domain_id"] for i in range(len(examples))])
 
         result: Dict[str, Union[np.ndarray, TensorPointer]] = {}
 
@@ -422,6 +425,7 @@ class DataCollatorForCLM:
         result["input_mask"] = TensorPointer(group_rank=self.input_pp_rank)
         result["label_ids"] = TensorPointer(group_rank=self.output_pp_rank)
         result["label_mask"] = TensorPointer(group_rank=self.output_pp_rank)
+        result["domain_id"] = TensorPointer(group_rank=self.output_pp_rank)
 
         assert (
             expanded_input_length == self.sequence_length + 1
@@ -436,6 +440,7 @@ class DataCollatorForCLM:
         if current_pp_rank == self.output_pp_rank:
             result["label_ids"] = input_ids[:, 1:]
             result["label_mask"] = np.ones((batch_size, self.sequence_length), dtype=np.bool_)
+            result["domain_id"] = domain_ids
 
         if isinstance(result["input_ids"], torch.Tensor) and result["input_ids"].shape[-1] != self.sequence_length:
             raise ValueError(
@@ -515,21 +520,24 @@ def get_train_dataloader(
         input_pp_rank,
         output_pp_rank,
     ]:
-        train_dataset = train_dataset.with_format(type="numpy", columns=["input_ids"], output_all_columns=True)
+        train_dataset = train_dataset.with_format(
+            type="numpy", columns=["input_ids", "domain_id"], output_all_columns=True
+        )
 
     # Case of ranks not requiring data. We give them an infinite dummy dataloader
     else:
         #
-        assert train_dataset.column_names == ["input_ids"], (
-            f"Dataset has to have a single column, with `input_ids` as the column name. "
+        assert train_dataset.column_names == ["input_ids", "domain_id"], (
+            f"Dataset has to have two columns, with `input_ids` and `domain_id` as the column names. "
             f"Current dataset: {train_dataset}"
         )
         dataset_length = len(train_dataset)
-        train_dataset = train_dataset.remove_columns(column_names="input_ids")
+        train_dataset = train_dataset.remove_columns(column_names=["input_ids", "domain_id"])
         assert (
             len(train_dataset) == 0
         ), f"Dataset has to be empty after removing the `input_ids` column. Current dataset: {train_dataset}"
-        # HACK as if we remove the last column of a train_dataset, it becomes empty and it's number of rows becomes empty.
+        # HACK as if we remove the last column of a train_dataset, it becomes empty and it's number of rows becomes 
+        # empty.
         train_dataset = EmptyInfiniteDataset(length=dataset_length)
         # No need to spawn a lot of workers, we can just use main
         dataloader_num_workers = 0

--- a/src/nanotron/dataloader.py
+++ b/src/nanotron/dataloader.py
@@ -126,6 +126,11 @@ def get_datasets(
     return raw_datasets
 
 
+def _add_id_column_to_dataset(ds: "DatasetDict", id: int, split: str = 'train') -> "DatasetDict":
+    id_column = [id] * len(ds)
+    return ds.add_column("domain_id", id_column)
+
+
 # Adapted from h4/src/h4/data/loading.py
 def _get_dataset_mix(dataset_dict: dict, splits: List[str] = None, seed=42) -> "DatasetDict":
     """
@@ -165,14 +170,18 @@ def _get_dataset_mix(dataset_dict: dict, splits: List[str] = None, seed=42) -> "
 
     if len(raw_train_datasets) > 0:
         train_subsets = []
-        for dataset, frac in zip(raw_train_datasets, fracs):
+        for idx, (dataset, frac) in enumerate(zip(raw_train_datasets, fracs)):
             train_subset = dataset.select(range(int(frac * len(dataset))))
+            train_subset = _add_id_column_to_dataset(train_subset, idx)
             train_subsets.append(train_subset)
         raw_datasets["train"] = concatenate_datasets(train_subsets).shuffle(seed=seed)
 
     # No subsampling for test datasets to enable fair comparison across models
     if len(raw_test_datasets) > 0:
-        raw_datasets["test"] = concatenate_datasets(raw_test_datasets).shuffle(seed=seed)
+        test_sets = []
+        for idx, raw_test_dataset in enumerate(raw_test_datasets):
+            test_sets.append(_add_id_column_to_dataset(raw_test_dataset, idx))
+        raw_datasets["test"] = concatenate_datasets(test_sets).shuffle(seed=seed)
 
     if len(raw_datasets) == 0:
         raise ValueError(
@@ -285,6 +294,7 @@ def clm_process(
     dataset_processing_num_proc_per_process: int,
     dataset_overwrite_cache: bool,
     sequence_length: int,
+    return_domain_ids: bool = False,
 ):
     """Concatenate all texts from raw_dataset and generate chunks of `sequence_length + 1`, where chunks overlap by a single token."""
     # Adapted from https://github.com/huggingface/transformers/blob/47e1676255e5dd86b9541f734cd4f4bdcbb50f4a/examples/pytorch/language-modeling/run_clm.py#L391-L439
@@ -310,6 +320,10 @@ def clm_process(
         tokenized_batch = tokenizer.batch_encode_plus(texts, return_attention_mask=False, return_token_type_ids=False)
         tokenized_batch = {k: [np.array(tokenized_texts) for tokenized_texts in v] for k, v in tokenized_batch.items()}
         return group_texts(tokenized_batch)
+
+    # TODO (sguo): the domain ids should be constructed here, some useful tips are given below
+    # 1. obtain the name of raw_dataset: raw_dataset.info.dataset_name
+    # 2. need a mapping between ids and names
 
     train_dataset = raw_dataset.map(
         _tokenize_and_group_texts,

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -1005,7 +1005,11 @@ class Loss(nn.Module):
                 # average loss over domains
                 avg_domain_losses = domain_losses / domain_token_counts
 
-                result.update({"domain_loss": avg_domain_losses})
+        # to satisify the output_keys check from PipelineBlock
+        if domain_ids is not None:
+            result.update({"domain_loss": avg_domain_losses})
+        else:
+            result.update({"domain_loss": -1 * torch.ones(self._num_domains, device='cuda', dtype=torch.float32)})
 
         return result
 
@@ -1028,8 +1032,9 @@ class LlamaForTraining(NanotronModel):
                 "sharded_logits",
                 "label_ids",
                 "label_mask",
+                "domain_ids",
             },
-            module_output_keys={"loss"},
+            module_output_keys={"loss", "domain_loss"},
         )
         self.parallel_context = parallel_context
         self.config = config
@@ -1041,17 +1046,19 @@ class LlamaForTraining(NanotronModel):
         input_mask: Union[torch.Tensor, TensorPointer],
         label_ids: Union[torch.Tensor, TensorPointer],
         label_mask: Union[torch.Tensor, TensorPointer],
+        domain_ids: Optional[torch.Tensor] = None, # [batch_size]
     ) -> Dict[str, Union[torch.Tensor, TensorPointer]]:
         sharded_logits = self.model(
             input_ids=input_ids,
             input_mask=input_mask,
         )
-        loss = self.loss(
+        metrics = self.loss(
             sharded_logits=sharded_logits,
             label_ids=label_ids,
             label_mask=label_mask,
-        )["loss"]
-        return {"loss": loss}
+            domain_ids=domain_ids,
+        )
+        return metrics
 
     @torch.no_grad()
     def init_model_randomly(self, config: Config):

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -1046,7 +1046,7 @@ class LlamaForTraining(NanotronModel):
         input_mask: Union[torch.Tensor, TensorPointer],
         label_ids: Union[torch.Tensor, TensorPointer],
         label_mask: Union[torch.Tensor, TensorPointer],
-        domain_ids: Optional[torch.Tensor] = None, # [batch_size]
+        domain_id: Optional[torch.Tensor] = None, # (batch_size,)
     ) -> Dict[str, Union[torch.Tensor, TensorPointer]]:
         sharded_logits = self.model(
             input_ids=input_ids,
@@ -1056,7 +1056,7 @@ class LlamaForTraining(NanotronModel):
             sharded_logits=sharded_logits,
             label_ids=label_ids,
             label_mask=label_mask,
-            domain_ids=domain_ids,
+            domain_ids=domain_id,
         )
         return metrics
 

--- a/src/nanotron/models/llama.py
+++ b/src/nanotron/models/llama.py
@@ -955,15 +955,20 @@ def masked_mean(loss, label_mask, dtype):
 
 
 class Loss(nn.Module):
+    # Reference: https://github.com/MaxiBoether/nanotron-streaming/blob/214ba79da9fa098f3e141e9a88d1f97f585a4f19/src/nanotron/models/llama.py#L957
     def __init__(self, tp_pg: dist.ProcessGroup):
         super().__init__()
         self.tp_pg = tp_pg
+        # Below are added for domain-wise losses
+        self._num_domains = 64 # TODO (sguo): check if 64 is large enough
+        self.has_per_domain_loss = False
 
     def forward(
         self,
         sharded_logits: torch.Tensor,  # [seq_length, batch_size, logits]
         label_ids: torch.Tensor,  # [batch_size, seq_length]
         label_mask: torch.Tensor,  # [batch_size, seq_length]
+        domain_ids: Optional[torch.Tensor] = None, # [batch_size]
     ) -> Dict[str, torch.Tensor]:
         # Megatron by defaults cast everything in fp32. `--f16-lm-cross-entropy` is an option you can use to keep current precision.
         # https://github.com/NVIDIA/Megatron-LM/blob/f267e6186eae1d6e2055b412b00e2e545a8e896a/megatron/model/gpt_model.py#L38
@@ -972,10 +977,37 @@ class Loss(nn.Module):
             sharded_logits, label_ids.transpose(0, 1).contiguous(), group=self.tp_pg, dtype=torch.float
         ).transpose(0, 1)
         # TODO @thomasw21: It's unclear what kind of normalization we want to do.
-        loss = masked_mean(loss, label_mask, dtype=torch.float)
+        avg_loss = masked_mean(loss, label_mask, dtype=torch.float)
         # I think indexing causes a sync we don't actually want
         # loss = loss[label_mask].sum()
-        return {"loss": loss}
+        result = {"loss": avg_loss}
+
+        # Begin of calculating domain-wise loss
+        if domain_ids is not None:
+            with torch.no_grad():
+                self.has_per_domain_loss = True
+                domain_ids = domain_ids.unsqueeze(-1).expand(-1, loss.size(1))  # [bs, seq_len]
+                masked_loss = loss * label_mask
+
+                # TODO (sguo): check if the domain_losses below is correct
+                # for each domain, get the overall loss
+                domain_losses = torch.zeros(self._num_domains, device='cuda', dtype=torch.float32)
+                domain_losses.scatter_add_(0, domain_ids.reshape(-1), masked_loss.reshape(-1))
+
+                 # for each domain, count the number of valid tokens
+                domain_token_counts = torch.zeros_like(domain_losses)
+                for domain_id in torch.unique(domain_ids):
+                   domain_mask = (domain_ids == domain_id)
+                   num_valid_tokens = (label_mask & domain_mask).sum()
+                   domain_token_counts[domain_id] = num_valid_tokens
+                domain_token_counts = torch.clamp(domain_token_counts, min=1) # to avoid underflow
+
+                # average loss over domains
+                avg_domain_losses = domain_losses / domain_token_counts
+
+                result.update({"domain_loss": avg_domain_losses})
+
+        return result
 
 
 class LlamaForTraining(NanotronModel):

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -462,9 +462,8 @@ class DistributedTrainer:
                     self.metadata.last_stage_idx
                 ].consumed_train_samples += self.global_batch_size
 
-                # TODO (sguo): add domain_loss_avg in to the train_step_logs
                 if (self.iteration_step - 1) % self.config.logging.iteration_step_info_interval == 0:
-                    self.train_step_logs(outputs=outputs, loss_avg=loss_avg)
+                    self.train_step_logs(outputs=outputs, loss_avg=loss_avg, domain_loss_avg=domain_loss_avg)
 
                 # Checkpoint
                 if self.iteration_step % self.config.checkpoints.checkpoint_interval == 0:
@@ -610,6 +609,7 @@ class DistributedTrainer:
         self,
         outputs: Iterable[Dict[str, Union[torch.Tensor, TensorPointer]]],
         loss_avg: Optional[torch.Tensor],
+        domain_loss_avg: Optional[torch.Tensor],
     ) -> None:
         # TODO @nouamanetazi: Megatron-LM seems to be using a barrier to report their interval time. Check if this is necessary. https://github.com/NouamaneTazi/Megatron-LM/blob/e241a96c3085b18e36c6cee1d68a8155de77b5a6/megatron/training.py#L607
         dist.barrier()
@@ -624,6 +624,7 @@ class DistributedTrainer:
             global_batch_size=self.global_batch_size,
         )
 
+        # TODO (sguo): log the input domain_loss_avg
         if dist.get_rank(self.parallel_context.world_pg) in self.logger_ranks:
             assert self.loggerwriter is not None, "loggerwriter should be defined on logger ranks"
 

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -452,7 +452,7 @@ class DistributedTrainer:
                 self._update_dataloader_based_on_training_stages(dataloader_or_dls)
 
                 # Training step
-                outputs, loss_avg = self.training_step(dataloader=self.current_dataloader)
+                outputs, loss_avg, domain_loss_avg = self.training_step(dataloader=self.current_dataloader)
 
                 # Training Logs
                 # TODO(xrsrke): refactor using callbacks would be better
@@ -462,6 +462,7 @@ class DistributedTrainer:
                     self.metadata.last_stage_idx
                 ].consumed_train_samples += self.global_batch_size
 
+                # TODO (sguo): add domain_loss_avg in to the train_step_logs
                 if (self.iteration_step - 1) % self.config.logging.iteration_step_info_interval == 0:
                     self.train_step_logs(outputs=outputs, loss_avg=loss_avg)
 
@@ -486,6 +487,7 @@ class DistributedTrainer:
         if self.iteration_step < self.initial_iter_step + 5:
             log_memory(logger=logger)
 
+        # NOTE: outputs below is now a list of dictionary with keys "loss" and "domain_loss"
         outputs = self.pipeline_engine.train_batch_iter(
             model=self.model,
             pg=self.parallel_context.pp_pg,
@@ -552,6 +554,18 @@ class DistributedTrainer:
             loss_avg = None
             handle = None
 
+        # Compute DP average domain loss
+        if isinstance(outputs[0]["domain_loss"], torch.Tensor):
+            # This is an average on only one data rank.
+            domain_loss_avg = torch.stack([output["domain_loss"] for output in outputs]).mean(dim=0) 
+            # sync domain loss across DP
+            domain_handle = dist.all_reduce(
+                domain_loss_avg, group=self.parallel_context.dp_pg, async_op=True, op=dist.ReduceOp.SUM
+            )
+        else:
+            domain_loss_avg = None
+            handle = None
+
         # Move optimizer states back to GPU before optimizer step
         if (
             self.init_checkpoint_path is not None
@@ -576,9 +590,13 @@ class DistributedTrainer:
         if handle is not None:
             handle.wait()
 
+        if domain_handle is not None:
+            domain_handle.wait()
+            domain_loss_avg.div_(self.config.parallelism.dp)
+
         self.post_train_step()
 
-        return outputs, loss_avg
+        return outputs, loss_avg, domain_loss_avg
 
     def validation_step(self, dataloader: Iterator[Dict[str, Union[torch.Tensor, TensorPointer]]]) -> Iterable[Dict]:
         outputs = self.pipeline_engine.validate_batch_iter(

--- a/src/nanotron/trainer.py
+++ b/src/nanotron/trainer.py
@@ -259,6 +259,10 @@ class DistributedTrainer:
 
         self.post_init()
 
+    def set_domain_name_id_mappings(self, name2id: Dict[str, int]) -> None:
+        self.domain_name2id = name2id
+        self.domain_id2name = {v: k for k, v in name2id.items()}
+
     def pre_init(self):
         self.init_checkpoint_path = parse_ckpt_path(config=self.config, parallel_context=self.parallel_context)
 
@@ -624,6 +628,10 @@ class DistributedTrainer:
             global_batch_size=self.global_batch_size,
         )
 
+        assert self.domain_id2name is not None and self.domain_name2id is not None, """
+            call `set_domain_name2id` before the training steps
+        """
+
         # TODO (sguo): log the input domain_loss_avg
         if dist.get_rank(self.parallel_context.world_pg) in self.logger_ranks:
             assert self.loggerwriter is not None, "loggerwriter should be defined on logger ranks"
@@ -648,6 +656,9 @@ class DistributedTrainer:
                 LogItem("model_tflops_per_gpu", model_tflops, "human_format"),  # , ".2f"),
                 LogItem("hardware_tflops_per_gpu", hardware_tflops, "human_format"),  # , ".2f"),
             ]
+
+            for idx, name in self.domain_id2name.items():
+                log_entries.append(LogItem(f"loss_on_{name}", domain_loss_avg[idx].item(), "human_format"))
 
             if self.config.optimizer.clip_grad is not None:
                 log_entries.append(LogItem("grad_norm", self.grad_norm_unclipped.item(), "human_format"))  # , ".3f"))


### PR DESCRIPTION
### Feature Description

This PR implement per-domain loss logging over all training stages and steps.
More precisely, given a mixture of datasets, we can track the loss on training samples from each dataset.
Below, the word "training mixture subset" and "domain" are used interchangeably. 

### Technical Details

1. `src/nanotron/dataloader.py` includes the following major updates:

   - Implement `_add_id_column_to_dataset` to add an extra column representing the domain indices to a dataset with only an `input_ids` column.
   - Update `_get_dataset_mix` to add `domain_id` column to datasets and return a mapping from domain name to their indices.
   - Update `groupt_texts` inside `clm_process` to guarantee that the samples in a single batch are from the same domain.
   - Update `DataCollatorForCLM` class to include `domain_id` in the input batches to the models

2. `src/nanotron/models/llama.py` includes the following major updates:

   - Re-implement the `forward` function of the class `Loss` to rearrange "per-sample loss" to "per-domain loss"
   - Minor changes in `LlamaForTraining` to calculate per domain metrics

3. `src/nanotron/trainer.py` includes the following major updates:

   - Implement `set_domain_name_id_mappings` to set up the mappings from domain names to domain indices
   - Update `training_step` function to get per domain loss over training
   - Update `train_step_logs` function to log the per domain loss

4. `run_train.py` includes only a few minor changes to get `domain_name2id` from dataset initialisation and pass it to `trainer`.

### Testing

Ran a few dummy trainings with the config file `examples/config_tiny_llama.yaml` on **a single node** with **a single GPU and multiple GPUs**.
